### PR TITLE
Limit sequence numbers between ranges

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,14 +1,8 @@
 import settings
-import json
-import html
 import logging
 import logging.handlers
-from flask import Flask, request, Response, jsonify, abort
+from flask import Flask, jsonify
 from pymongo import MongoClient
-import pymongo.errors
-from datetime import datetime
-from bson.objectid import ObjectId
-from bson.errors import InvalidId
 
 app = Flask(__name__)
 
@@ -21,27 +15,46 @@ db = mongo_client.sdx_sequences
 
 def get_next_sequence(seq_name):
     next_sequence = db.sequences.find_and_modify(query={'seq_name': seq_name},
-                                       update={'$inc': {'sequence': 1}},
-                                       upsert=True, new=True)
-    sequence_no = next_sequence['sequence']
-    return sequence_no
+                                                 update={'$inc': {'sequence': 1}},
+                                                 upsert=True, new=True)
+
+    return next_sequence['sequence']
 
 
 @app.route('/sequence', methods=['GET'])
 def do_get_sequence():
     sequence_no = get_next_sequence('sequence')
+
+    # Sequence numbers start at 1000 and increment to 9999
+    start = 1000
+    limit = 10000
+
+    sequence_no = sequence_no % limit + start
+
     return jsonify({'sequence_no': sequence_no})
 
 
 @app.route('/batch-sequence', methods=['GET'])
 def do_get_batch_sequence():
     sequence_no = get_next_sequence('batch-sequence')
+
+    start = 30000
+    limit = 10000
+
+    sequence_no = sequence_no % limit + start
+
     return jsonify({'sequence_no': sequence_no})
 
 
 @app.route('/image-sequence', methods=['GET'])
 def do_get_image_sequence():
     sequence_no = get_next_sequence('image-sequence')
+
+    start = 1
+    limit = 1000000000
+
+    sequence_no = sequence_no % limit + start
+
     return jsonify({'sequence_no': sequence_no})
 
 

--- a/server.py
+++ b/server.py
@@ -26,10 +26,10 @@ def do_get_sequence():
     sequence_no = get_next_sequence('sequence')
 
     # Sequence numbers start at 1000 and increment to 9999
-    start = 1000
-    limit = 10000
+    sequence_start = 1000
+    sequence_range = 9000
 
-    sequence_no = sequence_no % limit + start
+    sequence_no = (sequence_no - 1) % sequence_range + sequence_start
 
     return jsonify({'sequence_no': sequence_no})
 
@@ -38,10 +38,10 @@ def do_get_sequence():
 def do_get_batch_sequence():
     sequence_no = get_next_sequence('batch-sequence')
 
-    start = 30000
-    limit = 10000
+    sequence_start = 30000
+    sequence_range = 10000
 
-    sequence_no = sequence_no % limit + start
+    sequence_no = (sequence_no - 1) % sequence_range + sequence_start
 
     return jsonify({'sequence_no': sequence_no})
 
@@ -50,10 +50,10 @@ def do_get_batch_sequence():
 def do_get_image_sequence():
     sequence_no = get_next_sequence('image-sequence')
 
-    start = 1
-    limit = 1000000000
+    # start = 1
+    sequence_range = 1000000000
 
-    sequence_no = sequence_no % limit + start
+    sequence_no = sequence_no % sequence_range
 
     return jsonify({'sequence_no': sequence_no})
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,0 +1,93 @@
+from server import app
+import unittest
+import json
+import mock
+
+
+class TestSequenceService(unittest.TestCase):
+
+    sequence_endpoint = "/sequence"
+    batch_sequence_endpoint = "/batch-sequence"
+    image_sequence_endpoint = "/image-sequence"
+
+    def setUp(self):
+
+        # creates a test client
+        self.app = app.test_client()
+
+        # propagate the exceptions to the test client
+        self.app.testing = True
+
+    def mock_sequence_response(self, endpoint, mock_value, seq_start, seq_range, expected_sequence_no=False):
+        # Use the loop index as to mock a return param
+        with mock.patch('server.get_next_sequence', return_value=mock_value) as get_next_test_sequence:
+            r = self.app.get(endpoint)
+
+            expected = expected_sequence_no if expected_sequence_no else seq_start + (mock_value - 1) % seq_range
+
+            actual_response = json.loads(r.data.decode('UTF8'))
+            expected_response = {'sequence_no': expected}
+
+            self.assertEqual(actual_response, expected_response)
+
+    def test_increments_sequence(self):
+        sequence_start = 1000
+        sequence_range = 9000
+
+        test_start = 1
+        test_end = 10
+
+        for i in range(test_start, test_end):
+            self.mock_sequence_response(self.sequence_endpoint, i, sequence_start, sequence_range)
+
+    def test_increment_wraps_sequence(self):
+        sequence_start = 1000
+        sequence_range = 9000
+
+        test_start = 8998
+        test_end = 9003
+
+        for i in range(test_start, test_end):
+            self.mock_sequence_response(self.sequence_endpoint, i, sequence_start, sequence_range)
+
+    def test_increments_batch_sequence(self):
+        sequence_start = 30000
+        sequence_range = 10000
+
+        test_start = 8998
+        test_end = 9003
+
+        for i in range(test_start, test_end):
+            self.mock_sequence_response(self.batch_sequence_endpoint, i, sequence_start, sequence_range)
+
+    def test_increment_wraps_batch_sequence(self):
+        sequence_start = 30000
+        sequence_range = 10000
+
+        test_start = 39998
+        test_end = 40003
+
+        for i in range(test_start, test_end):
+            self.mock_sequence_response(self.batch_sequence_endpoint, i, sequence_start, sequence_range)
+
+    def test_increments_image_sequence(self):
+        sequence_start = 1
+        sequence_range = 1000000000
+
+        test_start = 1
+        test_end = 10
+
+        for i in range(test_start, test_end):
+            expected_seq_no = i % sequence_range
+            self.mock_sequence_response(self.image_sequence_endpoint, i, sequence_start, sequence_range, expected_sequence_no=expected_seq_no)
+
+    def test_increment_wraps_image_sequence(self):
+        sequence_start = 1
+        sequence_range = 1000000000
+
+        test_start = 9999999998
+        test_end = 1000000005
+
+        for i in range(test_start, test_end):
+            expected_seq_no = i % sequence_range
+            self.mock_sequence_response(self.image_sequence_endpoint, i, sequence_start, sequence_range, expected_sequence_no=expected_seq_no)


### PR DESCRIPTION
**Changes**

Set ranges for sequence number wraparounds based on previous logic in sdx-collect.

**How to test**

Request each of the endpoints /sequence, /batch-sequence, /image-sequence and check they start at the appropriate values.

**Who can test**

Anyone but @iwootten
