### PR TITLE
configurable logging level

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -4,6 +4,6 @@ import os
 logger = logging.getLogger(__name__)
 
 LOGGING_FORMAT = "%(asctime)s|%(levelname)s: sdx-sequence: %(message)s"
-LOGGING_LEVEL = logging.DEBUG
+LOGGING_LEVEL = logging.getLevelName(os.getenv('LOGGING_LEVEL', 'DEBUG'))
 
 MONGODB_URL = os.getenv("MONGODB_URL", "mongodb://localhost:27017")


### PR DESCRIPTION
**Changes**
Enables the logging level to be set by an environment variable

**How to test**
Should work the same by default
Set environment variable to a valid logging level

**Who can test**
Anyone but @elliott-jenkins
