### PR TITLE
Feature/log version number on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Log version number on startup
   - Add change log
 
 ### 1.3.0 2016-12-13

--- a/server.py
+++ b/server.py
@@ -90,6 +90,6 @@ if __name__ == '__main__':
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
     handler = logging.StreamHandler(sys.stdout)
     app.logger.addHandler(handler)
-    app.logger.info("Current version: {}".format(__version__))
+    app.logger.info("Starting server: version='{}'".format(__version__))
     port = int(os.getenv("PORT"))
     app.run(debug=True, host='0.0.0.0', port=port)

--- a/server.py
+++ b/server.py
@@ -7,6 +7,8 @@ import os
 from flask import Flask, jsonify
 from pymongo import MongoClient
 
+__version__ = "1.3.0"
+
 app = Flask(__name__)
 
 app.config['MONGODB_URL'] = settings.MONGODB_URL
@@ -88,5 +90,6 @@ if __name__ == '__main__':
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
     handler = logging.StreamHandler(sys.stdout)
     app.logger.addHandler(handler)
+    app.logger.info("Current version: {}".format(__version__))
     port = int(os.getenv("PORT"))
     app.run(debug=True, host='0.0.0.0', port=port)


### PR DESCRIPTION
This is a pull request to add functionality that logs the current version number on service startup. The `__version__` variable in `server.py` contains the current release value, which will need to be manually updated on a new release being cut. The version is logged at INFO level.