### PR TITLE
Remove SDX_HOME from makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+    - "3.6"
     - "3.5"
     - "3.4"
 sudo: required
@@ -8,12 +9,9 @@ before_script:
     - psql -c "create user sdx with password 'sdx';" -U postgres
     - psql -c "grant all privileges on database sdx to sdx;" -U postgres
     - psql -d sdx -a -f setup/schema.sql -U sdx
-before_install:
-    - git clone https://github.com/ONSdigital/sdx-common.git
-    - pip3 install ./sdx-common
 install:
-    - pip install -r requirements.txt
-    - pip install -r test_requirements.txt
+    - make clean
+    - make build
     - pip install codecov
 script:
     - make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Change all instances of ADD to COPY in Dockerfile
+  - Remove use of SDX_HOME variable in makefile
 
 ### 2.0.0 2017-07-10
   - Use Postgres backend via SQLAlchemy ORM.

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,13 @@
-dev: check-env
-	if pip list | grep sdx-common; \
-	then \
-		cd .. && pip3 uninstall -y sdx-common && pip3 install -I ./sdx-common; \
-	else \
-		cd .. && pip3 install -I ./sdx-common; \
-	fi;
-
-	pip3 install -r requirements.txt
-
 build:
+	git clone -b 0.7.0 https://github.com/ONSdigital/sdx-common.git
+	pip install ./sdx-common
 	pip3 install -r requirements.txt
+	rm -rf sdx-common
 
 test:
 	pip3 install -r test_requirements.txt
 	flake8 --exclude ./lib/*
 	python3 -m unittest tests/*.py
 
-check-env:
-ifeq ($(SDX_HOME),)
-	$(error SDX_HOME is not set)
-endif
+clean:
+	rm -rf sdx-common


### PR DESCRIPTION
## What? and Why?
Removes unused SDX_HOME from makefile. Not required but build would fail if it wasn't supplied.
Also corrects order of make targets.

Supersedes #31 