### PR TITLE
Updating cloud foundry python

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.1
+python-3.6.3


### PR DESCRIPTION
## What? and Why?
Upgrade python as 3.6.1 doesn't exist in cloud foundry anymore

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
