### PR TITLE
Update travis and fix most of the security issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
+dist: xenial
 python:
+    - "3.7"
     - "3.6"
-    - "3.5"
-    - "3.4"
 sudo: required
 before_install:
     - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ install:
 script:
     - make test
     - pytest -v tests/ --cov=server --cov-report html
-dist: trusty
 after_success:
     - codecov
 services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ### Unreleased
+  - Remove python 3.4 and 3.5 from travis builds
+  - Add python 3.7 to travis builds
+  - Upgrade urllib3 and Jinja2 to fix security issues.
 
 ### 2.5.1 2019-02-19
   - Update packages to fix security issues

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ Flask==0.12.4 \
     --hash=sha256:6c02dbaa5a9ef790d8219bdced392e2d549c10cd5a5ba4b6aa65126b2271af29
 itsdangerous==0.24 \
     --hash=sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519
-Jinja2==2.9.6 \
-    --hash=sha256:2231bace0dfd8d2bf1e5d7e41239c06c9e0ded46e70cc1094a0aa64b0afeb054 \
-    --hash=sha256:ddaa01a212cd6d641401cb01b605f4a4d9f37bfc93043d7f760ec70fb99ff9ff
+Jinja2==2.10.1 \
+    --hash=sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013 \
+    --hash=sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b
 MarkupSafe==1.0 \
     --hash=sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665
 Werkzeug==0.12.2 \
@@ -226,6 +226,6 @@ chardet==3.0.4 \
 certifi==2018.11.29 \
     --hash=sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7 \
     --hash=sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033
-urllib3==1.24.1 \
-    --hash=sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39 \
-    --hash=sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22
+urllib3==1.24.2 \
+    --hash=sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0 \
+    --hash=sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3


### PR DESCRIPTION
## What? and Why?
Since upgrading everything to 3.6, we no longer need to test 3.4 and 3.5.
Also added 3.7 for when we eventually upgrade to it so we can have confidence that it works
Also fixed most of the security issues.  Left the postgres one as upgrading it caused warnings.  Will be looked at as part of another card.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
